### PR TITLE
Added empty line to SIP req

### DIFF
--- a/SIP/externalscripts/check_sip
+++ b/SIP/externalscripts/check_sip
@@ -146,6 +146,7 @@ sub buildReq
   $req .= "Max-Forwards: 70\n";
   $req .= "User-agent: check_sip $VERSION\n";
   $req .= "Accept: text/plain\n";
+  $req .= "\n";
   return $req;
 }
 


### PR DESCRIPTION
Added empty line to end of sip request.
The SIP header should have an empty line at the end of the header and before the body. But this was omitted and caused some PBXes to reject the packet. I have added this and the script is compatable with more PBXes